### PR TITLE
feat: Add editable playlist name input on review tracks page

### DIFF
--- a/src/pages/review-tracks.tsx
+++ b/src/pages/review-tracks.tsx
@@ -273,7 +273,7 @@ export default function ReviewTracks() {
               maxLength={100}
             />
             <p className="text-xs text-gray-500 mt-2">
-              This will be the name of your Spotify playlist
+              This will be the name of your Spotify playlist ({playlistName.length}/100 characters)
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Added an editable input field for customizing the playlist name before creation
- Defaults to "Festival Mix - [date]" but users can now change it to anything they want
- Includes validation to prevent empty playlist names
- Input is properly disabled during playlist creation to prevent changes mid-process

## Changes
- Added `playlistName` state with sensible default value
- Created a styled input field with label and helper text
- Added validation for empty playlist names
- Updated API call to use the custom playlist name
- Applied 100 character limit to prevent excessively long names

## Test plan
- [x] Verify default playlist name appears in input field
- [ ] Test editing the playlist name
- [ ] Test creating playlist with custom name
- [ ] Test validation: try creating with empty name
- [ ] Verify input is disabled during playlist creation
- [ ] Verify playlist appears in Spotify with the custom name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can customize playlist names with a pre-filled default that includes the current date.
  * A playlist name input is shown (placeholder, max length) and is disabled while a playlist is being created.
  * Playlist names are trimmed before sending and only non-empty names are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->