### PR TITLE
Fix playlist cover upload error to Spotify

### DIFF
--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -15,6 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const scopes = [
     'playlist-modify-public',
     'playlist-modify-private',
+    'ugc-image-upload', // Required for uploading custom playlist covers
     'user-read-email',
     'user-read-private',
   ].join(' ');


### PR DESCRIPTION
- Add missing 'ugc-image-upload' scope required for Spotify playlist cover uploads
- Improve error logging in uploadPlaylistCover to show detailed Spotify API errors
- Add base64 size validation and transformRequest to ensure proper data format
- Add specific error messages for 401 (unauthorized) and 403 (forbidden) responses

Users will need to log out and log back in to get the new OAuth scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image size validation to prevent uploads exceeding Spotify's limits.
  * Enhanced Spotify account permissions to support image upload functionality.

* **Bug Fixes**
  * Improved error messages with clearer diagnostics for authentication and API issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->