### PR TITLE
Research artist appearances across festivals

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -61,6 +61,7 @@ export const searchTracksSchema = z.object({
         message: 'All artist names in perArtistCounts must be non-empty strings',
       }
     ),
+  trackSelectionMode: z.enum(['popular', 'balanced', 'deep-cuts']).optional(),
 });
 
 // ============================================================================

--- a/src/pages/api/search-tracks.ts
+++ b/src/pages/api/search-tracks.ts
@@ -36,7 +36,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
   }
 
-  const { artists, trackCountMode, customTrackCount, perArtistCounts } = validatedData;
+  const { artists, trackCountMode, customTrackCount, perArtistCounts, trackSelectionMode } =
+    validatedData;
 
   // Check if mock data mode is enabled
   if (process.env.USE_MOCK_DATA === 'true') {
@@ -84,7 +85,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     // Search for artists and get their top tracks with rate limiting
-    console.log(`Searching tracks for ${artists.length} artists`);
+    console.log(
+      `Searching tracks for ${artists.length} artists (selection mode: ${trackSelectionMode || 'popular'})`
+    );
     const { tracks, foundArtists, artistMatches } = await searchAndGetTopTracks(
       artists,
       accessToken,
@@ -92,6 +95,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         mode: trackCountMode || 'tier-based',
         customCount: customTrackCount,
         perArtistCounts: sanitizedPerArtistCounts,
+        trackSelectionMode: trackSelectionMode || 'popular',
       }
     );
 

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import axios from 'axios';
-import { Artist, AnalyzeResponse } from '@/types';
+import { Artist, AnalyzeResponse, TrackSelectionMode } from '@/types';
 
 // Fun loading messages
 const loadingMessages = [
@@ -86,6 +86,9 @@ export default function Upload() {
   const [customTrackCount, setCustomTrackCount] = useState(3);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [perArtistCounts, setPerArtistCounts] = useState<Record<string, number>>({});
+
+  // Track selection mode state
+  const [trackSelectionMode, setTrackSelectionMode] = useState<TrackSelectionMode>('popular');
 
   const checkAuth = useCallback(async () => {
     try {
@@ -217,6 +220,7 @@ export default function Upload() {
         trackCountMode: trackCountMode,
         customTrackCount: trackCountMode === 'custom' ? customTrackCount : undefined,
         perArtistCounts: Object.keys(perArtistCounts).length > 0 ? perArtistCounts : undefined,
+        trackSelectionMode: trackSelectionMode,
       });
 
       // Store tracks and poster thumbnail in sessionStorage for the review page
@@ -556,6 +560,77 @@ export default function Upload() {
                           <span className="text-sm text-gray-600">tracks for all artists</span>
                         </div>
                       </label>
+                    </div>
+
+                    {/* Track Selection Mode */}
+                    <div className="mt-4 pt-4 border-t border-gray-200">
+                      <h5 className="font-medium text-gray-800 mb-2">Track Selection Style</h5>
+                      <div className="space-y-2">
+                        <label className="flex items-start cursor-pointer">
+                          <input
+                            type="radio"
+                            name="trackSelectionMode"
+                            value="popular"
+                            checked={trackSelectionMode === 'popular'}
+                            onChange={(e) =>
+                              setTrackSelectionMode(e.target.value as TrackSelectionMode)
+                            }
+                            className="mt-1 mr-2"
+                          />
+                          <div>
+                            <div className="font-medium text-gray-800">
+                              🔥 Popular Hits Only{' '}
+                              <span className="text-green-600 text-sm">(Default)</span>
+                            </div>
+                            <div className="text-xs text-gray-500 ml-0 mt-1">
+                              Each artist&apos;s most popular tracks (top 4)
+                            </div>
+                          </div>
+                        </label>
+
+                        <label className="flex items-start cursor-pointer">
+                          <input
+                            type="radio"
+                            name="trackSelectionMode"
+                            value="balanced"
+                            checked={trackSelectionMode === 'balanced'}
+                            onChange={(e) =>
+                              setTrackSelectionMode(e.target.value as TrackSelectionMode)
+                            }
+                            className="mt-1 mr-2"
+                          />
+                          <div>
+                            <div className="font-medium text-gray-800">🎵 Balanced Mix</div>
+                            <div className="text-xs text-gray-500 ml-0 mt-1">
+                              Mix of popular and lesser-known tracks (top 8)
+                            </div>
+                          </div>
+                        </label>
+
+                        <label className="flex items-start cursor-pointer">
+                          <input
+                            type="radio"
+                            name="trackSelectionMode"
+                            value="deep-cuts"
+                            checked={trackSelectionMode === 'deep-cuts'}
+                            onChange={(e) =>
+                              setTrackSelectionMode(e.target.value as TrackSelectionMode)
+                            }
+                            className="mt-1 mr-2"
+                          />
+                          <div>
+                            <div className="font-medium text-gray-800">
+                              💎 Deep Cuts & Hidden Gems
+                            </div>
+                            <div className="text-xs text-gray-500 ml-0 mt-1">
+                              Lesser-known tracks for true fans (tracks 6-10)
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <div className="mt-2 text-xs text-gray-500 italic">
+                        💡 Tip: Try different modes to discover new tracks from the same artists!
+                      </div>
                     </div>
 
                     {/* Advanced customization toggle */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,3 +48,5 @@ export interface SearchTracksResponse {
   artistsSearched: number;
   tracksFound: number;
 }
+
+export type TrackSelectionMode = 'popular' | 'balanced' | 'deep-cuts';


### PR DESCRIPTION
Implements a new track selection mode feature that allows users to choose between popular hits, balanced mix, or deep cuts when creating playlists. This addresses the issue where the same artists across different festivals would produce identical playlists.

Changes:
- Added TrackSelectionMode type ('popular' | 'balanced' | 'deep-cuts')
- Updated getArtistTopTracks() to randomize selection within popularity ranges:
  - 'popular': Top 4 most popular tracks
  - 'balanced': Top 8 tracks (good mix)
  - 'deep-cuts': Tracks 6-10 (lesser-known gems)
- Added UI control on upload page for track selection mode
- Updated searchAndGetTopTracks() to accept and pass trackSelectionMode
- Updated /api/search-tracks to handle trackSelectionMode parameter
- Added validation schema for trackSelectionMode

Benefits:
- Creates unique playlists even for the same festival/artists
- Gives users control over track diversity
- Balances between mainstream appeal and discovery
- Default mode is 'popular' to maintain familiar behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added track selection modes to customize artist track curation. Users can now choose between "popular" (top hits), "balanced" (mixed selection), or "deep-cuts" (deeper album tracks) when generating playlists. Selection preference is available in the upload interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->