### PR TITLE
feat: upgrade Gemini model to 3.5 Flash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Music Posters is a Next.js application that converts festival poster images into Spotify playlists using AI. It's a stateless MVP built for speed, supporting three image analysis providers:
 
 - **Google Cloud Vision API** (OCR-based): Traditional text extraction with heuristic filtering
-- **Gemini 2.0 Flash** (Vision-first AI): Direct image analysis with intelligent artist ranking by visual prominence
+- **Gemini 3.5 Flash** (Vision-first AI): Direct image analysis with intelligent artist ranking by visual prominence
 - **Hybrid Mode** (Best of both): Combines Vision OCR for comprehensive text extraction with Gemini AI for intelligent filtering and ranking
 
 All providers integrate with Spotify Web API for playlist creation. Switch providers via environment variable.
@@ -86,7 +86,7 @@ NEXTAUTH_SECRET=<generate with: openssl rand -base64 32>
 - **Auth**: OAuth 2.0 with httpOnly cookies (no database)
 - **Image Analysis**:
   - Google Cloud Vision API (OCR + filtering)
-  - Gemini 2.0 Flash (vision-first AI with ranking)
+  - Gemini 3.5 Flash (vision-first AI with ranking)
   - Hybrid Mode (Vision OCR + Gemini AI)
 - **External Services**: Spotify Web API
 
@@ -110,7 +110,7 @@ NEXTAUTH_SECRET=<generate with: openssl rand -base64 32>
    │  └─ Returns Artist[] (weight: undefined)
    │
    ├─ IF provider='gemini':
-   │  ├─ Gemini 2.0 Flash analyzes image with vision
+   │  ├─ Gemini 3.5 Flash analyzes image with vision
    │  ├─ Few-shot prompt guides artist extraction
    │  ├─ Returns Artist[] with weight scores (1-10)
    │  └─ Artists ranked by font size/position
@@ -213,7 +213,7 @@ Vision-first AI analysis with intelligent ranking. Uses few-shot prompting with 
 
 **Analysis Process**:
 
-1. Image sent directly to Gemini 2.0 Flash (no OCR step)
+1. Image sent directly to Gemini 3.5 Flash (no OCR step)
 2. AI analyzes visual hierarchy: font size, position, styling
 3. Returns Artist[] with:
    - `weight`: 1-10 prominence score (10=headliner, 1=undercard)
@@ -422,7 +422,7 @@ const detections = result.textAnnotations;
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+const model = genAI.getGenerativeModel({ model: 'gemini-3.5-flash' });
 ```
 
 **Getting API Key**:

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -91,7 +91,7 @@ If no event name is visible, set "eventName" to "".
 Be precise with artist spellings. No additional text, only the JSON object.`;
 
 /**
- * Analyzes a festival poster image using Gemini 2.0 Flash
+ * Analyzes a festival poster image using Gemini 3.5 Flash
  * @param imageBuffer - Buffer containing the image data
  * @param mimeType - MIME type of the image (e.g., 'image/jpeg', 'image/png', 'image/webp')
  * @returns Object with artists array and raw Gemini response
@@ -112,7 +112,7 @@ export async function analyzeImageWithGemini(
 
   // Initialize Gemini client
   const genAI = new GoogleGenerativeAI(apiKey);
-  const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-3.5-flash' });
 
   try {
     console.log('[Gemini] Analyzing poster image...');

--- a/src/lib/hybrid-analyzer.ts
+++ b/src/lib/hybrid-analyzer.ts
@@ -133,7 +133,7 @@ async function analyzeWithGeminiAndOCR(
 
   // Initialize Gemini client
   const genAI = new GoogleGenerativeAI(apiKey);
-  const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-3.5-flash' });
 
   console.log('[Hybrid/Gemini] Analyzing poster with OCR context...');
 

--- a/src/pages/api/analyze.ts
+++ b/src/pages/api/analyze.ts
@@ -104,7 +104,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       console.log('[Analyze API] Analyzing with Hybrid Mode (Vision + Gemini)...');
       result = await analyzeImageHybrid(imageBuffer, imageFile.mimetype ?? 'image/jpeg');
     } else if (provider === 'gemini') {
-      // Use Gemini 2.0 Flash with vision-first approach
+      // Use Gemini 3.5 Flash with vision-first approach
       console.log('[Analyze API] Analyzing with Gemini...');
       result = await analyzeImageWithGeminiRetry(imageBuffer, imageFile.mimetype ?? 'image/jpeg');
     } else {


### PR DESCRIPTION
## What

Bumps the vision model from `gemini-2.5-flash` to `gemini-3.5-flash` in both the Gemini and hybrid analyzers, and syncs stale `CLAUDE.md`/code-comment references that still named `gemini-2.0-flash-exp`.

## Why

The configured model was a generation behind. `gemini-3.5-flash` is the current GA balanced-tier Flash model with the strongest vision-reasoning, which is what the artist-ranking-by-prominence logic depends on. Cost rises (~$0.0001 → ~$0.0005 per poster) but stays negligible at this volume.

## Changes

- `src/lib/gemini.ts` — model → `gemini-3.5-flash` (+ doc comment)
- `src/lib/hybrid-analyzer.ts` — model → `gemini-3.5-flash`
- `src/pages/api/analyze.ts` — comment sync
- `CLAUDE.md` — 5 stale `2.0`/`2.5` references updated

## Verification

Ran a real hybrid analysis (Vision OCR + Gemini 3.5 Flash) on a 72-artist festival poster via `/api/analyze`:
- HTTP 200, 72 artists extracted with correct weighted/tiered rankings (headliners at weight 10, sub-headliners at 7)
- Logs: "Gemini analysis attempt 1/3" → "Both Vision and Gemini succeeded" — first-try success, no retries, no fallback to vision-only

Note: only the `hybrid` provider path was exercised end-to-end. The pure `gemini` provider path shares the same model string and parser (low risk, untested directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project documentation to reflect current Gemini model version.

* **Chores**
  * Upgraded image analysis engine to use Gemini 3.5 Flash, replacing previous model versions for improved performance across all analysis methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enrique7mc/music-posters/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->