### PR TITLE
fix(test): polyfill localStorage so MSW loads under Node 25 (#38)

### DIFF
--- a/src/test/polyfills.ts
+++ b/src/test/polyfills.ts
@@ -1,0 +1,47 @@
+/**
+ * localStorage polyfill for the test environment.
+ *
+ * Node 25 enables the experimental Web Storage API by default, exposing a
+ * global `localStorage` that throws unless the process was started with a
+ * valid `--localstorage-file`. That broken global shadows jsdom's own
+ * implementation, so `localStorage.getItem` is not a function. When
+ * `msw/node` imports, its `CookieStore` calls `localStorage.getItem(...)` at
+ * module-eval time and the whole vitest suite dies at collection. See GitHub
+ * issue #38.
+ *
+ * This file is the FIRST entry in vitest's `setupFiles`, so it runs before
+ * `./setup.ts` imports the MSW server. It only replaces `localStorage` when
+ * the present one is broken, leaving a working jsdom/native implementation
+ * untouched on other Node versions.
+ */
+function createInMemoryStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear() {
+      store = {};
+    },
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    key(index: number) {
+      return Object.keys(store)[index] ?? null;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+  } as Storage;
+}
+
+if (typeof globalThis.localStorage?.getItem !== 'function') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: createInMemoryStorage(),
+    writable: true,
+    configurable: true,
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
+    setupFiles: ['./src/test/polyfills.ts', './src/test/setup.ts'],
     exclude: ['node_modules/', '.next/', 'dist/'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Fixes #38.

## Problem

`npm run test:run` failed at **suite-collection time** — all 14 test files errored before any test ran, with `TypeError: localStorage.getItem is not a function` originating in `msw/node`'s `CookieStore`.

## Root cause

Confirmed the issue's hypothesis:

- Node 25.9.0 enables the **experimental Web Storage API by default**, exposing a global `localStorage` that is broken unless started with a valid `--localstorage-file`. (`node -e "typeof localStorage"` → `'object'`, but `localStorage.getItem` → `undefined`.)
- That broken global **shadows jsdom's** localStorage — probing inside the jsdom test env showed both `localStorage.getItem` and `window.localStorage.getItem` were `undefined`.
- `src/test/setup.ts` imports the MSW server, whose `CookieStore` calls `localStorage.getItem(...)` **at module-eval time**. Every suite loads the setup file, so the entire run died at collection.

Purely a toolchain/environment incompatibility; product code is unaffected.

## Fix

Added `src/test/polyfills.ts` (in-memory `Storage`) as the **first** entry in vitest's `setupFiles`, so it runs before MSW is imported:

```ts
setupFiles: ['./src/test/polyfills.ts', './src/test/setup.ts']
```

It only replaces `localStorage` when the present one is broken/missing, leaving native/jsdom implementations untouched on other Node versions. Chosen over pinning Node (`.nvmrc`/`engines`) or a `--no-experimental-webstorage` flag because it's **Node-version-independent** and needs no flags.

## Verification

`npm run test:run` → **14 files / 143 tests pass**.

(The `--localstorage-file` warning still prints — now harmless Node worker-init noise, not a failure.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)