### PR TITLE
ci: add typecheck gate and clear the 38 pre-existing tsc errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm run test:run
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",

--- a/src/lib/__tests__/api-dev/config.test.ts
+++ b/src/lib/__tests__/api-dev/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 import handler from '@/pages/api/dev/config';
 import { resetDevConfig } from '@/lib/dev-mode';
@@ -11,6 +11,7 @@ describe('/api/dev/config', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...originalEnv };
     resetDevConfig();
   });
@@ -28,7 +29,7 @@ describe('/api/dev/config', () => {
 
   it('GET returns 403 when dev mode unavailable', () => {
     delete process.env.DEV_MODE;
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     const { req, res } = createReq('GET');
     handler(req, res);
@@ -38,7 +39,7 @@ describe('/api/dev/config', () => {
 
   it('GET returns config when dev mode available', () => {
     process.env.DEV_MODE = 'true';
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     const { req, res } = createReq('GET');
     handler(req, res);
@@ -54,7 +55,7 @@ describe('/api/dev/config', () => {
 
   it('PATCH merges and returns updated config', () => {
     process.env.DEV_MODE = 'true';
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     const { req, res } = createReq('PATCH', { mockAnalysis: true, mockDelayMs: 500 });
     handler(req, res);
@@ -67,7 +68,7 @@ describe('/api/dev/config', () => {
 
   it('PATCH with invalid body returns 400', () => {
     process.env.DEV_MODE = 'true';
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     const { req, res } = createReq('PATCH', { mockAnalysis: 'not-a-boolean' });
     handler(req, res);
@@ -79,7 +80,7 @@ describe('/api/dev/config', () => {
 
   it('rejects non-localhost requests', () => {
     process.env.DEV_MODE = 'true';
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     const { req, res } = createMocks({
       method: 'GET',
@@ -95,7 +96,7 @@ describe('/api/dev/config', () => {
 
   it('returns 405 for unsupported methods', () => {
     process.env.DEV_MODE = 'true';
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     const { req, res } = createReq('DELETE');
     handler(req, res);

--- a/src/lib/__tests__/api-dev/create-playlist-dev.test.ts
+++ b/src/lib/__tests__/api-dev/create-playlist-dev.test.ts
@@ -19,13 +19,14 @@ describe('/api/create-playlist (dev mode)', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...originalEnv };
     resetDevConfig();
   });
 
   it('dry-run returns fake URL without hitting APIs', async () => {
     process.env.DEV_MODE = 'true';
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
     resetDevConfig();
     updateDevConfig({ skipAuth: true, dryRunPlaylist: true });
 

--- a/src/lib/__tests__/api-dev/me-dev.test.ts
+++ b/src/lib/__tests__/api-dev/me-dev.test.ts
@@ -15,13 +15,14 @@ describe('/api/auth/me (dev mode)', () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...originalEnv };
     resetDevConfig();
   });
 
   it('returns fake user when skipAuth is enabled', async () => {
     process.env.DEV_MODE = 'true';
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
     resetDevConfig();
     updateDevConfig({ skipAuth: true, fakePlatform: 'spotify' });
 

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { NextApiRequest, NextApiResponse } from 'next';
 import {
   setAuthCookies,
@@ -16,9 +16,8 @@ import { resetDevConfig, updateDevConfig } from '../dev-mode';
 describe('auth.ts', () => {
   describe('setAuthCookies', () => {
     it('should set access and refresh token cookies', () => {
-      const mockRes = {
-        setHeader: vi.fn(),
-      } as unknown as NextApiResponse;
+      const setHeader = vi.fn();
+      const mockRes = { setHeader } as unknown as NextApiResponse;
 
       setAuthCookies(mockRes, 'access_token_123', 'refresh_token_456', 3600);
 
@@ -32,48 +31,44 @@ describe('auth.ts', () => {
     });
 
     it('should set httpOnly flag on cookies', () => {
-      const mockRes = {
-        setHeader: vi.fn(),
-      } as unknown as NextApiResponse;
+      const setHeader = vi.fn();
+      const mockRes = { setHeader } as unknown as NextApiResponse;
 
       setAuthCookies(mockRes, 'access_token_123', 'refresh_token_456', 3600);
 
-      const cookies = mockRes.setHeader.mock.calls[0][1] as string[];
+      const cookies = setHeader.mock.calls[0][1] as string[];
       expect(cookies[0]).toContain('HttpOnly');
       expect(cookies[1]).toContain('HttpOnly');
     });
 
     it('should set SameSite=lax on cookies', () => {
-      const mockRes = {
-        setHeader: vi.fn(),
-      } as unknown as NextApiResponse;
+      const setHeader = vi.fn();
+      const mockRes = { setHeader } as unknown as NextApiResponse;
 
       setAuthCookies(mockRes, 'access_token_123', 'refresh_token_456', 3600);
 
-      const cookies = mockRes.setHeader.mock.calls[0][1] as string[];
+      const cookies = setHeader.mock.calls[0][1] as string[];
       expect(cookies[0]).toContain('SameSite=Lax');
       expect(cookies[1]).toContain('SameSite=Lax');
     });
 
     it('should set correct Max-Age for access token', () => {
-      const mockRes = {
-        setHeader: vi.fn(),
-      } as unknown as NextApiResponse;
+      const setHeader = vi.fn();
+      const mockRes = { setHeader } as unknown as NextApiResponse;
 
       setAuthCookies(mockRes, 'access_token_123', 'refresh_token_456', 3600);
 
-      const cookies = mockRes.setHeader.mock.calls[0][1] as string[];
+      const cookies = setHeader.mock.calls[0][1] as string[];
       expect(cookies[0]).toContain('Max-Age=3600');
     });
 
     it('should set 30 day Max-Age for refresh token', () => {
-      const mockRes = {
-        setHeader: vi.fn(),
-      } as unknown as NextApiResponse;
+      const setHeader = vi.fn();
+      const mockRes = { setHeader } as unknown as NextApiResponse;
 
       setAuthCookies(mockRes, 'access_token_123', 'refresh_token_456', 3600);
 
-      const cookies = mockRes.setHeader.mock.calls[0][1] as string[];
+      const cookies = setHeader.mock.calls[0][1] as string[];
       const expectedMaxAge = 60 * 60 * 24 * 30; // 30 days
       expect(cookies[1]).toContain(`Max-Age=${expectedMaxAge}`);
     });
@@ -153,9 +148,8 @@ describe('auth.ts', () => {
 
   describe('clearAuthCookies', () => {
     it('should clear access and refresh token cookies', () => {
-      const mockRes = {
-        setHeader: vi.fn(),
-      } as unknown as NextApiResponse;
+      const setHeader = vi.fn();
+      const mockRes = { setHeader } as unknown as NextApiResponse;
 
       clearAuthCookies(mockRes);
 
@@ -169,13 +163,12 @@ describe('auth.ts', () => {
     });
 
     it('should set Max-Age=0 to expire cookies immediately', () => {
-      const mockRes = {
-        setHeader: vi.fn(),
-      } as unknown as NextApiResponse;
+      const setHeader = vi.fn();
+      const mockRes = { setHeader } as unknown as NextApiResponse;
 
       clearAuthCookies(mockRes);
 
-      const cookies = mockRes.setHeader.mock.calls[0][1] as string[];
+      const cookies = setHeader.mock.calls[0][1] as string[];
       expect(cookies[0]).toContain('Max-Age=0');
       expect(cookies[1]).toContain('Max-Age=0');
     });
@@ -218,6 +211,7 @@ describe('auth.ts', () => {
     const originalEnv = { ...process.env };
 
     afterEach(() => {
+      vi.unstubAllEnvs();
       process.env = { ...originalEnv };
       resetDevConfig();
     });
@@ -235,7 +229,7 @@ describe('auth.ts', () => {
 
     it('isAuthenticatedOrDev returns true when skipAuth enabled', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
       resetDevConfig();
 
       updateDevConfig({ skipAuth: true });
@@ -249,7 +243,7 @@ describe('auth.ts', () => {
 
     it('getPlatformAccessTokenOrDev returns fake token when skipAuth enabled', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
       resetDevConfig();
 
       updateDevConfig({ skipAuth: true });
@@ -263,7 +257,7 @@ describe('auth.ts', () => {
 
     it('getAuthenticatedPlatformOrDev returns fakePlatform when skipAuth enabled', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
       resetDevConfig();
 
       updateDevConfig({ skipAuth: true, fakePlatform: 'apple-music' });
@@ -277,7 +271,7 @@ describe('auth.ts', () => {
 
     it('wrappers delegate to real functions when dev mode on but skipAuth off', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
       resetDevConfig();
 
       const mockReq = {

--- a/src/lib/__tests__/dev-mode.test.ts
+++ b/src/lib/__tests__/dev-mode.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { isDevModeAvailable, getDevConfig, updateDevConfig, resetDevConfig } from '../dev-mode';
 
 describe('dev-mode.ts', () => {
@@ -9,6 +9,7 @@ describe('dev-mode.ts', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...originalEnv };
     resetDevConfig();
   });
@@ -16,28 +17,28 @@ describe('dev-mode.ts', () => {
   describe('isDevModeAvailable', () => {
     it('returns false when NODE_ENV=production', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('NODE_ENV', 'production');
 
       expect(isDevModeAvailable()).toBe(false);
     });
 
     it('returns false when DEV_MODE is unset', () => {
       delete process.env.DEV_MODE;
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       expect(isDevModeAvailable()).toBe(false);
     });
 
     it('returns true when DEV_MODE=true and NODE_ENV is not production', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       expect(isDevModeAvailable()).toBe(true);
     });
 
     it('returns false when DEV_MODE=false', () => {
       process.env.DEV_MODE = 'false';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       expect(isDevModeAvailable()).toBe(false);
     });
@@ -46,7 +47,7 @@ describe('dev-mode.ts', () => {
   describe('getDevConfig', () => {
     it('returns all-disabled config when dev mode not available', () => {
       delete process.env.DEV_MODE;
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       const config = getDevConfig();
 
@@ -59,7 +60,7 @@ describe('dev-mode.ts', () => {
 
     it('defaults mockAnalysis and mockTrackSearch to false', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       const config = getDevConfig();
 
@@ -70,7 +71,7 @@ describe('dev-mode.ts', () => {
 
     it('reads MOCK_DATA_DELAY_MS for initial delay value', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
       process.env.MOCK_DATA_DELAY_MS = '2000';
 
       const config = getDevConfig();
@@ -80,7 +81,7 @@ describe('dev-mode.ts', () => {
 
     it('ignores invalid MOCK_DATA_DELAY_MS values', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
       process.env.MOCK_DATA_DELAY_MS = 'abc';
 
       const config = getDevConfig();
@@ -90,7 +91,7 @@ describe('dev-mode.ts', () => {
 
     it('defaults fakePlatform to spotify', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       const config = getDevConfig();
 
@@ -101,7 +102,7 @@ describe('dev-mode.ts', () => {
   describe('updateDevConfig', () => {
     it('enforces skipAuth → dryRunPlaylist coupling', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       const config = updateDevConfig({ skipAuth: true, dryRunPlaylist: false });
 
@@ -112,7 +113,7 @@ describe('dev-mode.ts', () => {
 
     it('allows dryRunPlaylist=true without skipAuth', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       const config = updateDevConfig({ dryRunPlaylist: true, skipAuth: false });
 
@@ -122,28 +123,28 @@ describe('dev-mode.ts', () => {
 
     it('throws when dev mode is not available', () => {
       delete process.env.DEV_MODE;
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       expect(() => updateDevConfig({ mockAnalysis: true })).toThrow('Dev mode is not available');
     });
 
     it('throws on invalid config key', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       expect(() => updateDevConfig({ invalidKey: true } as any)).toThrow('Invalid config key');
     });
 
     it('throws on invalid type', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       expect(() => updateDevConfig({ mockAnalysis: 'yes' } as any)).toThrow('Invalid type');
     });
 
     it('throws on invalid fakePlatform value', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       expect(() => updateDevConfig({ fakePlatform: 'tidal' as any })).toThrow(
         'Invalid fakePlatform'
@@ -152,14 +153,14 @@ describe('dev-mode.ts', () => {
 
     it('throws on out-of-range mockDelayMs', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       expect(() => updateDevConfig({ mockDelayMs: 10000 })).toThrow('mockDelayMs must be between');
     });
 
     it('merges partial updates', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'development';
+      vi.stubEnv('NODE_ENV', 'development');
 
       updateDevConfig({ mockAnalysis: true });
       const config = updateDevConfig({ mockTrackSearch: true });
@@ -172,7 +173,7 @@ describe('dev-mode.ts', () => {
   describe('security boundary', () => {
     it('NODE_ENV=production + DEV_MODE=true → all dev features OFF', () => {
       process.env.DEV_MODE = 'true';
-      process.env.NODE_ENV = 'production';
+      vi.stubEnv('NODE_ENV', 'production');
 
       expect(isDevModeAvailable()).toBe(false);
 

--- a/src/lib/music-platform/__tests__/apple-music-platform.test.ts
+++ b/src/lib/music-platform/__tests__/apple-music-platform.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mocks/server';
 import { AppleMusicPlatformService } from '../apple-music-platform';
@@ -188,7 +189,8 @@ describe('AppleMusicPlatformService.searchArtist', () => {
 describe('AppleMusicPlatformService error redaction (errMessage)', () => {
   const SECRET = 'SUPERSECRET_DEV_TOKEN_do_not_log';
   let service: AppleMusicPlatformService;
-  let errorSpy: ReturnType<typeof vi.spyOn>;
+  // Explicit type: ReturnType<typeof vi.spyOn> infers a constructor signature.
+  let errorSpy: MockInstance<(...args: unknown[]) => void>;
 
   beforeEach(() => {
     service = new AppleMusicPlatformService();

--- a/src/pages/api/__tests__/health.test.ts
+++ b/src/pages/api/__tests__/health.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createMocks } from 'node-mocks-http';
+import type { RequestMethod } from 'node-mocks-http';
 import handler from '../health';
 
 describe('/api/health', () => {
@@ -32,7 +33,7 @@ describe('/api/health', () => {
   });
 
   it('should work with any HTTP method', () => {
-    const methods = ['GET', 'POST', 'PUT', 'DELETE'];
+    const methods: RequestMethod[] = ['GET', 'POST', 'PUT', 'DELETE'];
 
     methods.forEach((method) => {
       const { req, res } = createMocks({ method });


### PR DESCRIPTION
Closes #42

## Summary

- `npx tsc --noEmit` reported **38 errors** on `main`, none of which had ever failed a build — CI never typechecked, and `next build` doesn't compile test files
- All 38 are fixed, and a `typecheck` step now gates CI so they can't come back
- Every error was in a **test file**; no production code changes
- The issue says 39; it's 38 because #41 already fixed the `vi.spyOn` instance in `spotify-platform.test.ts`

## Changes

### TS2540 — `Cannot assign to 'NODE_ENV'` (30 errors, 5 files)

Replaced direct `process.env.NODE_ENV = …` mutation with `vi.stubEnv('NODE_ENV', …)`, plus `vi.unstubAllEnvs()` in each `afterEach`.

Beyond satisfying the compiler this closes a real leak: env changes previously relied on hand-rolled save/restore and could bleed between tests. The existing `process.env = { ...originalEnv }` restores are kept — they still cover `DEV_MODE` and friends.

Used per-file `unstubAllEnvs()` rather than global `unstubEnvs: true` in `vitest.config.ts`, to avoid changing teardown for every test in the repo.

### TS2339 — `Property 'mock' does not exist` (5 errors, `auth.test.ts`)

`const mockRes = { setHeader: vi.fn() } as unknown as NextApiResponse` erased the `Mock` type, so `.mock.calls` didn't exist. The `vi.fn()` now lives in its own binding — `mockRes` keeps the honest `NextApiResponse` type at call sites, while `setHeader` retains `.mock` for assertions.

### TS2322 (2 errors)

- `apple-music-platform.test.ts` — `ReturnType<typeof vi.spyOn>` infers a constructor signature; replaced with an explicit `MockInstance<(...args: unknown[]) => void>` (matching the fix already in `spotify-platform.test.ts`)
- `health.test.ts` — `['GET', 'POST', …]` inferred as `string[]`; typed as `RequestMethod[]` from `node-mocks-http`

### TS2304 (1 error)

Added the missing `afterEach` import in `auth.test.ts`.

### The gate

- `package.json` — `"typecheck": "tsc --noEmit"`
- `.github/workflows/test.yml` — a `Typecheck` step **before** `Run tests`, mirroring the existing lint step

No `any`, `@ts-ignore`, `@ts-expect-error`, or `@ts-nocheck` — verified by grepping the diff, per the issue's acceptance criteria.

## Test plan

- [x] `npm run typecheck` — exit 0, no output (was 38 errors on `main`)
- [x] **Gate actually bites** — a deliberate type error makes it exit 2; 0 once removed. A gate that passes on broken code would be worthless
- [x] `npx vitest run` — **216 passing**, 21 files
- [x] `npm run lint` — 0 errors, 4 warnings; **identical count on `main`**, so pre-existing and not introduced here
- [x] `git diff --name-only` — only test files, `package.json`, and the workflow
- [ ] The CI step itself is verified by this PR's own run — that's the first execution of the new workflow step

## Notes for review

- `npm run build` was deliberately not run locally: a dev server was live on :3000, and building while it's up corrupts `.next`. It also adds no signal here, since `next build` doesn't compile test files — which is the exact gap this closes.
- GitHub Actions had a major outage on 2026-08-06 ("job was not acquired by Runner of type hosted"). If this run fails with empty `steps`, that's infrastructure, not code — re-run rather than debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLELELSyE7434xWBsHoFuN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test environment isolation and cleanup for more reliable results.
  - Strengthened type safety in API health, authentication, and music platform tests.
  - Preserved existing development-mode, configuration, validation, and security checks.

- **Chores**
  - Added a TypeScript type-checking command.
  - Included type checking in the automated validation workflow before tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->